### PR TITLE
Fix javascript argument parsing and add type conversion

### DIFF
--- a/gh-pages/src/documentation/data/XMLData.js
+++ b/gh-pages/src/documentation/data/XMLData.js
@@ -101,6 +101,7 @@ const settingsUsage = [`<Settings>
     <AutoSetPageWhenSeen>true</AutoSetPageWhenSeen>
     <PageSound>false</PageSound>
     <ForceStartPage>true</ForceStartPage>
+    <ConvertArgumentTypes>true</ConvertArgumentTypes>
 </Settings>`];
 
 //language=XML
@@ -999,6 +1000,7 @@ export const XmlData = [
         <li><b>AutoSetPageWhenSeen</b>: Adds the page name as a flag when the page is viewed. <RequiredBadge/></li>
         <li><b>PageSound</b>: Play the page change sound when changing pages. <RequiredBadge/></li>
         <li><b>ForceStartPage</b>: Force the guide to start on the "start" page every time it is loaded. <RequiredBadge/></li>
+        <li><b>ConvertArgumentTypes</b>: Convert arguments from javascript called by buttons, timers, etc. to non-string types when appropriate. <RequiredBadge/></li>
       </ul>
     </>,
     usage: settingsUsage,

--- a/src/main/java/org/guideme/guideme/readers/XmlGuideReader.java
+++ b/src/main/java/org/guideme/guideme/readers/XmlGuideReader.java
@@ -919,7 +919,14 @@ public class XmlGuideReader {
 										} else {
 											guideSettings.setPageSound(false); 
 										}
-									}	        				 
+									} else if (reader.getName().getLocalPart().equals("ConvertArgumentTypes")) {
+										reader.next();
+										if (reader.getEventType() == XMLStreamConstants.CHARACTERS) {
+											guideSettings.setConvertArgumentTypes(Boolean.parseBoolean(reader.getText()));
+										} else {
+											guideSettings.setConvertArgumentTypes(false);
+										}
+									}
 								}
 								eventType2 = reader.next();
 								if (eventType2 == XMLStreamConstants.END_ELEMENT) {

--- a/src/main/java/org/guideme/guideme/scripting/Jscript.java
+++ b/src/main/java/org/guideme/guideme/scripting/Jscript.java
@@ -79,8 +79,10 @@ public class Jscript  implements Runnable
 			if (nodeType == Token.CALL && !foundCall) {
 				foundCall = true;
 				for (AstNode n2 : ((FunctionCall) node).getArguments()) {
-					//args.add(n2.toSource());
-					args.add(nodeToObj(n2));
+					if (guideSettings.isConvertArgumentTypes())
+						args.add(nodeToObj(n2));
+					else
+						args.add(n2.toSource());
 				}
 			}
 

--- a/src/main/java/org/guideme/guideme/scripting/Jscript.java
+++ b/src/main/java/org/guideme/guideme/scripting/Jscript.java
@@ -19,9 +19,7 @@ import org.guideme.guideme.settings.GuideSettings;
 import org.guideme.guideme.settings.UserSettings;
 import org.guideme.guideme.ui.MainShell;
 import org.mozilla.javascript.*;
-import org.mozilla.javascript.ast.AstNode;
-import org.mozilla.javascript.ast.AstRoot;
-import org.mozilla.javascript.ast.NodeVisitor;
+import org.mozilla.javascript.ast.*;
 import org.mozilla.javascript.tools.debugger.Main;
 
 public class Jscript  implements Runnable
@@ -68,10 +66,8 @@ public class Jscript  implements Runnable
 
 	public class SimpleNodeVisitor implements NodeVisitor
 	{
-		private AstNode firstCall = null;
+		private boolean foundCall = false;
 		private ArrayList<Object> args = new ArrayList<Object>();
-		private boolean seenName = false; 	//Used to handle "the first item with the function as the parent will be the name of the function".
-											//This is probably not the best way to handle this. Actually, could a name as an argument even work?
 
 		@Override
 		public boolean visit(AstNode node) {
@@ -79,23 +75,21 @@ public class Jscript  implements Runnable
 				return false;
 
 			int nodeType = node.getType();
-			if (nodeType == Token.CALL && firstCall == null) {
-				firstCall = node;
+			if (nodeType == Token.CALL && !foundCall) {
+				foundCall = true;
+				for (AstNode n2 : ((FunctionCall) node).getArguments()) {
+					args.add(n2.toSource());
+				}
 			}
 
-			AstNode parent = node.getParent();
-			if (parent == firstCall && parent != null && (seenName || nodeType != Token.NAME)) {
-				args.add(node.toSource());
-			}
-
-			if (nodeType == Token.NAME)
-				seenName = true;
 			return true;
 		}
 
 		public ArrayList<Object> getArgs() {
 			return args;
 		}
+
+
 	}
 
 

--- a/src/main/java/org/guideme/guideme/settings/GuideSettings.java
+++ b/src/main/java/org/guideme/guideme/settings/GuideSettings.java
@@ -50,6 +50,7 @@ public class GuideSettings{
 	private boolean pageSound = true;
 	private boolean forceStartPage = false;
 	private boolean globalScriptLogged = false;
+	private boolean convertArgumentTypes = false;
 	private static Logger logger = LogManager.getLogger();
 	private ComonFunctions comonFunctions = ComonFunctions.getComonFunctions();
 	private Scriptable scope;
@@ -569,6 +570,10 @@ public class GuideSettings{
 	public void setGlobalScriptLogged(boolean globalScriptLogged) {
 		this.globalScriptLogged = globalScriptLogged;
 	}
+
+	public boolean isConvertArgumentTypes() { return convertArgumentTypes; }
+
+	public void setConvertArgumentTypes(boolean convertArgumentTypes) {this.convertArgumentTypes = convertArgumentTypes; }
 
 	public void setScriptVar(String key, Object var) {
 		scriptVariables.put(key, var);


### PR DESCRIPTION
Use Rhino to parse arguments to JavaScript functions called from timers, buttons, etc. (Resolves issues with quoting from EroticDevelopment/GuideMe#19)
Added ConvertArgumentTypes option to settings - if true, most simple and composite literals will be converted into suitable object types. (Strings, numbers, null, true, and false will be converted, as will arrays and hashes of those types. Names will be replaced with the value of that name from ScriptVars. Regular expressions and template strings are not processed and will be passed as strings, as will any other unrecognized constructions.)